### PR TITLE
Upgrade to Rake v13 as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gemspec
 
 gem "benchmark-ips"
 gem "pry"
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rake-compiler"


### PR DESCRIPTION
Rake v12 is not compatible with Ruby 3.0 due to kwargs changes.