### PR TITLE
Fix native extension building on XCode 14

### DIFF
--- a/ext/oj-introspect/extconf.rb
+++ b/ext/oj-introspect/extconf.rb
@@ -7,6 +7,22 @@ oj_version_file_path = Pathname.new(oj_version_file)
 
 OJ_HEADERS = oj_version_file_path.join('..', '..', '..', 'ext', 'oj').to_s
 
+cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
+if cc_version.match?(/clang/i)
+  # Ignore symbols loaded from Oj in case Ruby is compiled without
+  # "-Wl,-undefined,dynamic_lookup" (related to https://bugs.ruby-lang.org/issues/19005)
+  symfile = File.join(__dir__, 'oj.sym')
+  dynamic_symbols = File.readlines(symfile)
+  dynamic_symbols.each do |sym|
+    $DLDFLAGS << " -Wl,-U,#{sym.strip}"
+  end
+
+  # Needed for Ruby 3.2 ABI check: https://github.com/ruby/ruby/pull/5474
+  if RUBY_VERSION >= "3.2"
+    $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"
+  end
+end
+
 dir_config('oj', [OJ_HEADERS], [])
 
 create_makefile("oj/introspect/introspect_ext")

--- a/ext/oj-introspect/oj.sym
+++ b/ext/oj-introspect/oj.sym
@@ -1,0 +1,3 @@
+_oj_init_usual
+_oj_parser_new
+_oj_parser_set_option


### PR DESCRIPTION
XCode 14 on macOS compiles Ruby 2.7.5 without the linker flag
`-Wl,-undefined,dynamic_lookup`, as reported
in https://bugs.ruby-lang.org/issues/19005. As a result, the build
step fails:

```
linking shared-object oj/introspect/introspect_ext.bundle
Undefined symbols for architecture arm64:
  "_oj_init_usual", referenced from:
      _rb_new_introspect_parser in introspect.o
  "_oj_parser_new", referenced from:
      _rb_new_introspect_parser in introspect.o
  "_oj_parser_set_option", referenced from:
      _rb_new_introspect_parser in introspect.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:262: introspect_ext.bundle] Error 1
```

This commit ignores the symbols needed from Oj so that compilation
will not fail if these are not available.

In addition, this commit ensures `_ruby_abi_version` is exported for
Ruby 3.2 to support https://github.com/ruby/ruby/pull/5474.