### PR TITLE
Fix _ruby_abi_version symbol not found with Ruby 3.2.0

### DIFF
--- a/ext/oj-introspect/extconf.rb
+++ b/ext/oj-introspect/extconf.rb
@@ -18,7 +18,7 @@ if cc_version.match?(/clang/i)
   end
 
   # Needed for Ruby 3.2 ABI check: https://github.com/ruby/ruby/pull/5474
-  if RUBY_VERSION >= "3.2"
+  if RUBY_VERSION >= "3.2" && RUBY_PATCHLEVEL < 0
     $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"
   end
 end

--- a/ext/oj-introspect/extconf.rb
+++ b/ext/oj-introspect/extconf.rb
@@ -8,7 +8,7 @@ oj_version_file_path = Pathname.new(oj_version_file)
 OJ_HEADERS = oj_version_file_path.join('..', '..', '..', 'ext', 'oj').to_s
 
 cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
-if cc_version.match?(/clang/i)
+if cc_version.match?(/clang/i) && RUBY_PLATFORM =~ /darwin/
   # Ignore symbols loaded from Oj in case Ruby is compiled without
   # "-Wl,-undefined,dynamic_lookup" (related to https://bugs.ruby-lang.org/issues/19005)
   symfile = File.join(__dir__, 'oj.sym')


### PR DESCRIPTION
When compiling Ruby 3.2.0 on an Apple M1, this error results:

```
compiling ../../../../ext/oj-introspect/introspect.c
linking shared-object oj/introspect/introspect_ext.bundle
Undefined symbols for architecture arm64:
  "_ruby_abi_version", referenced from:
     -exported_symbol[s_list] command line option
ld: symbol(s) not found for architecture arm64
```

`_ruby_abi_version` is only exported on development builds (https://github.com/redis-rb/redis-client/issues/58#issuecomment-1396463441).